### PR TITLE
resolve task statuses from list instead of space

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -98,6 +98,10 @@ export interface List {
   name: string
 }
 
+export interface ListWithStatuses extends List {
+  statuses: SpaceStatus[]
+}
+
 interface Folder {
   id: string
   name: string
@@ -259,6 +263,10 @@ export class ClickUpClient {
 
   async getSpaceWithStatuses(spaceId: string): Promise<SpaceWithStatuses> {
     return this.request<SpaceWithStatuses>(`/space/${spaceId}`)
+  }
+
+  async getListWithStatuses(listId: string): Promise<ListWithStatuses> {
+    return this.request<ListWithStatuses>(`/list/${listId}`)
   }
 
   async getSpaces(teamId: string): Promise<Space[]> {

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -105,10 +105,8 @@ async function resolveStatus(
   statusInput: string,
 ): Promise<string> {
   const task = await client.getTask(taskId)
-  if (!task.space) return statusInput
-
-  const space = await client.getSpaceWithStatuses(task.space.id)
-  const available = space.statuses.map(s => s.status)
+  const list = await client.getListWithStatuses(task.list.id)
+  const available = list.statuses.map(s => s.status)
   const matched = matchStatus(statusInput, available)
 
   if (!matched) {


### PR DESCRIPTION
Closes #14

When validating `--status` on `cu update`, the CLI was fetching statuses from the task's space. Lists can define their own statuses that differ from the space defaults, causing valid statuses to be rejected.

This changes `resolveStatus` to fetch statuses from the task's list (`GET /list/<id>`) instead.