### PR TITLE
Add ClickUp Docs API v3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,10 +245,13 @@ Status: :white_check_mark: implemented | :construction: planned | :no_entry_sign
 
 ### Docs
 
-| Feature           | Command            | Status         |
-| ----------------- | ------------------ | -------------- |
-| Search docs       | `cup docs <query>` | :construction: |
-| View page content | `cup doc <id>`     | :construction: |
+| Feature           | Command                              | Status             |
+| ----------------- | ------------------------------------ | ------------------ |
+| Search docs       | `cup docs [query]`                   | :white_check_mark: |
+| View page content | `cup doc <docId> <pageId>`           | :white_check_mark: |
+| Create doc        | `cup doc-create <title>`             | :white_check_mark: |
+| Create page       | `cup doc-page-create <docId> <name>` | :white_check_mark: |
+| Edit page         | `cup doc-page-edit <docId> <pageId>` | :white_check_mark: |
 
 ### Attachments
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6,51 +6,56 @@ All `<id>` and `<taskId>` arguments accept both native ClickUp IDs (e.g., `abc12
 
 ## Quick Reference
 
-| Command                          | Description                           |
-| -------------------------------- | ------------------------------------- |
-| `cup init`                       | First-time setup wizard               |
-| **Read**                         |                                       |
-| `cup tasks`                      | List tasks assigned to me             |
-| `cup sprint`                     | My tasks in the active sprint         |
-| `cup sprints`                    | List all sprints across folders       |
-| `cup assigned`                   | My tasks grouped by pipeline stage    |
-| `cup inbox`                      | Recently updated tasks assigned to me |
-| `cup task <id>`                  | Get task details                      |
-| `cup subtasks <id>`              | List subtasks of a task               |
-| `cup comments <id>`              | List comments on a task               |
-| `cup activity <id>`              | Task details + comment history        |
-| `cup lists <spaceId>`            | List all lists in a space             |
-| `cup spaces`                     | List spaces in workspace              |
-| `cup open <query>`               | Open a task in the browser            |
-| `cup search <query>`             | Search my tasks by name               |
-| `cup summary`                    | Daily standup helper                  |
-| `cup overdue`                    | Tasks past their due date             |
-| `cup auth`                       | Check authentication status           |
-| **Write**                        |                                       |
-| `cup update <id>`                | Update a task                         |
-| `cup create`                     | Create a new task                     |
-| `cup delete <id>`                | Delete a task                         |
-| `cup field <id>`                 | Set or remove custom field values     |
-| `cup comment <id>`               | Post a comment on a task              |
-| `cup comment-edit <commentId>`   | Edit an existing comment              |
-| `cup comment-delete <commentId>` | Delete a comment                      |
-| `cup replies <commentId>`        | List threaded replies on a comment    |
-| `cup reply <commentId>`          | Reply to a comment                    |
-| `cup link <taskId> <linksTo>`    | Add or remove a link between tasks    |
-| `cup attach <taskId> <filePath>` | Upload a file attachment to a task    |
-| `cup assign <id>`                | Assign or unassign users              |
-| `cup depend <id>`                | Add or remove task dependencies       |
-| `cup move <id>`                  | Add or remove a task from a list      |
-| `cup tag <id>`                   | Add or remove tags on a task          |
-| `cup checklist`                  | Manage checklists on tasks            |
-| `cup time start <taskId>`        | Start tracking time on a task         |
-| `cup time stop`                  | Stop the running timer                |
-| `cup time status`                | Show the currently running timer      |
-| `cup time log <taskId> <dur>`    | Log a manual time entry               |
-| `cup time list`                  | List recent time entries              |
-| **Configuration**                |                                       |
-| `cup config`                     | Manage CLI configuration              |
-| `cup completion <shell>`         | Output shell completion script        |
+| Command                              | Description                           |
+| ------------------------------------ | ------------------------------------- |
+| `cup init`                           | First-time setup wizard               |
+| **Read**                             |                                       |
+| `cup tasks`                          | List tasks assigned to me             |
+| `cup sprint`                         | My tasks in the active sprint         |
+| `cup sprints`                        | List all sprints across folders       |
+| `cup assigned`                       | My tasks grouped by pipeline stage    |
+| `cup inbox`                          | Recently updated tasks assigned to me |
+| `cup task <id>`                      | Get task details                      |
+| `cup subtasks <id>`                  | List subtasks of a task               |
+| `cup comments <id>`                  | List comments on a task               |
+| `cup activity <id>`                  | Task details + comment history        |
+| `cup lists <spaceId>`                | List all lists in a space             |
+| `cup spaces`                         | List spaces in workspace              |
+| `cup open <query>`                   | Open a task in the browser            |
+| `cup search <query>`                 | Search my tasks by name               |
+| `cup summary`                        | Daily standup helper                  |
+| `cup overdue`                        | Tasks past their due date             |
+| `cup auth`                           | Check authentication status           |
+| `cup docs [query]`                   | List workspace docs                   |
+| `cup doc <docId> <pageId>`           | View a doc page                       |
+| **Write**                            |                                       |
+| `cup update <id>`                    | Update a task                         |
+| `cup create`                         | Create a new task                     |
+| `cup delete <id>`                    | Delete a task                         |
+| `cup field <id>`                     | Set or remove custom field values     |
+| `cup comment <id>`                   | Post a comment on a task              |
+| `cup comment-edit <commentId>`       | Edit an existing comment              |
+| `cup comment-delete <commentId>`     | Delete a comment                      |
+| `cup replies <commentId>`            | List threaded replies on a comment    |
+| `cup reply <commentId>`              | Reply to a comment                    |
+| `cup link <taskId> <linksTo>`        | Add or remove a link between tasks    |
+| `cup attach <taskId> <filePath>`     | Upload a file attachment to a task    |
+| `cup assign <id>`                    | Assign or unassign users              |
+| `cup depend <id>`                    | Add or remove task dependencies       |
+| `cup move <id>`                      | Add or remove a task from a list      |
+| `cup tag <id>`                       | Add or remove tags on a task          |
+| `cup checklist`                      | Manage checklists on tasks            |
+| `cup time start <taskId>`            | Start tracking time on a task         |
+| `cup time stop`                      | Stop the running timer                |
+| `cup time status`                    | Show the currently running timer      |
+| `cup time log <taskId> <dur>`        | Log a manual time entry               |
+| `cup time list`                      | List recent time entries              |
+| `cup doc-create <title>`             | Create a new doc                      |
+| `cup doc-page-create <docId> <name>` | Create a page in a doc                |
+| `cup doc-page-edit <docId> <pageId>` | Edit a doc page                       |
+| **Configuration**                    |                                       |
+| `cup config`                         | Manage CLI configuration              |
+| `cup completion <shell>`             | Output shell completion script        |
 
 ---
 
@@ -265,6 +270,33 @@ Check authentication status. Validates your API token and shows your user info.
 cup auth
 cup auth --json
 ```
+
+### `cup docs [query]`
+
+List docs in your workspace. Optionally filter by name.
+
+```bash
+cup docs
+cup docs "design"
+cup docs --json
+```
+
+| Flag     | Required | Description       |
+| -------- | -------- | ----------------- |
+| `--json` | no       | Force JSON output |
+
+### `cup doc <docId> <pageId>`
+
+View a doc page. Returns markdown content.
+
+```bash
+cup doc abc123 page456
+cup doc abc123 page456 --json
+```
+
+| Flag     | Required | Description       |
+| -------- | -------- | ----------------- |
+| `--json` | no       | Force JSON output |
 
 ---
 
@@ -633,6 +665,55 @@ cup time list --days 7 --json
 | `--days <n>`      | no       | Number of days to look back (default: 7) |
 | `--task <taskId>` | no       | Filter entries by task ID                |
 | `--json`          | no       | Force JSON output                        |
+
+### `cup doc-create <title>`
+
+Create a new doc in your workspace.
+
+```bash
+cup doc-create "Architecture Notes"
+cup doc-create "Draft" -c "# Initial content"
+cup doc-create "Plan" --json
+```
+
+| Flag            | Required | Description                |
+| --------------- | -------- | -------------------------- |
+| `-c, --content` | no       | Initial content (markdown) |
+| `--json`        | no       | Force JSON output          |
+
+### `cup doc-page-create <docId> <name>`
+
+Create a page in a doc. Optionally nest under a parent page.
+
+```bash
+cup doc-page-create abc123 "Getting Started"
+cup doc-page-create abc123 "Setup" -c "# Setup guide"
+cup doc-page-create abc123 "Sub Section" --parent-page page456
+cup doc-page-create abc123 "Page" --json
+```
+
+| Flag                     | Required | Description                |
+| ------------------------ | -------- | -------------------------- |
+| `-c, --content`          | no       | Page content (markdown)    |
+| `--parent-page <pageId>` | no       | Parent page ID for nesting |
+| `--json`                 | no       | Force JSON output          |
+
+### `cup doc-page-edit <docId> <pageId>`
+
+Edit a doc page name or content. Provide at least `--name` or `--content`.
+
+```bash
+cup doc-page-edit abc123 page456 --name "Renamed Section"
+cup doc-page-edit abc123 page456 -c "# Updated content"
+cup doc-page-edit abc123 page456 --name "New Name" -c "# New body"
+cup doc-page-edit abc123 page456 --name "Renamed" --json
+```
+
+| Flag            | Required   | Description                 |
+| --------------- | ---------- | --------------------------- |
+| `--name <text>` | one of two | New page name               |
+| `-c, --content` | one of two | New page content (markdown) |
+| `--json`        | no         | Force JSON output           |
 
 ---
 

--- a/skills/clickup-cli/SKILL.md
+++ b/skills/clickup-cli/SKILL.md
@@ -52,6 +52,8 @@ All commands support `--help` for full flag details.
 | `cup lists <spaceId> [--name partial] [--json]`                                                     | Lists in a space (including folder lists)          |
 | `cup open <query> [--json]`                                                                         | Open task in browser by ID or name                 |
 | `cup auth [--json]`                                                                                 | Check authentication status                        |
+| `cup docs [query] [--json]`                                                                         | List workspace docs (optionally filter by name)    |
+| `cup doc <docId> <pageId> [--json]`                                                                 | View a doc page (markdown content)                 |
 
 ### Write
 
@@ -83,6 +85,9 @@ All commands support `--help` for full flag details.
 | `cup time status [--json]`                                                                                                                                                          | Show currently running timer                               |
 | `cup time log <taskId> <duration> [-d desc] [--json]`                                                                                                                               | Log manual time entry (e.g. "2h", "30m")                   |
 | `cup time list [--days n] [--task id] [--json]`                                                                                                                                     | List recent time entries                                   |
+| `cup doc-create <title> [-c content] [--json]`                                                                                                                                      | Create a new doc                                           |
+| `cup doc-page-create <docId> <name> [-c content] [--parent-page pageId] [--json]`                                                                                                   | Create a page in a doc                                     |
+| `cup doc-page-edit <docId> <pageId> [--name text] [-c content] [--json]`                                                                                                            | Edit a doc page                                            |
 | `cup config get <key>` / `cup config set <key> <value>` / `cup config path`                                                                                                         | Manage CLI config (keys: apiToken, teamId, sprintFolderId) |
 | `cup completion <shell>`                                                                                                                                                            | Shell completions (bash/zsh/fish)                          |
 
@@ -124,6 +129,11 @@ All commands support `--help` for full flag details.
 | `cup link` + custom IDs     | Both IDs must be the same type (both custom or both native). Mixing may not work                                                                                                                                                                          |
 | `cup link`                  | Link/unlink tasks (different from dependencies)                                                                                                                                                                                                           |
 | `cup attach`                | Upload files to tasks. Attachments shown in `cup task` detail view                                                                                                                                                                                        |
+| `cup docs`                  | List and search workspace docs by name                                                                                                                                                                                                                    |
+| `cup doc`                   | View a doc page content (markdown)                                                                                                                                                                                                                        |
+| `cup doc-create`            | Create a new doc with optional initial content                                                                                                                                                                                                            |
+| `cup doc-page-create`       | Create a page in a doc, optionally nested under a parent page                                                                                                                                                                                             |
+| `cup doc-page-edit`         | Edit a doc page name or content                                                                                                                                                                                                                           |
 | `cup task`                  | Shows custom fields, checklists, attachments, dependencies, and linked tasks in detail view                                                                                                                                                               |
 | `cup lists`                 | Discovers list IDs needed for `--list` and `cup create -l`                                                                                                                                                                                                |
 | Errors                      | stderr with exit code 1                                                                                                                                                                                                                                   |
@@ -193,6 +203,20 @@ cup time stop                                      # stop timer
 cup time log abc123def 2h -d "Code review"         # log manual entry
 cup time list --days 7                             # recent entries
 cup delete abc123def --confirm          # irreversible!
+```
+
+### Work with docs
+
+```bash
+cup docs                                       # list all docs
+cup docs "design"                              # search docs by name
+cup doc <docId> <pageId>                       # view page content
+cup doc-create "Architecture Notes"            # create a doc
+cup doc-create "Notes" -c "# Draft"            # create with content
+cup doc-page-create <docId> "New Section"      # add page to doc
+cup doc-page-create <docId> "Sub" --parent-page <pageId>  # nested page
+cup doc-page-edit <docId> <pageId> --name "Renamed"       # rename page
+cup doc-page-edit <docId> <pageId> -c "# Updated content" # edit content
 ```
 
 ### Discover workspace structure

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,5 @@
 const BASE_URL = 'https://api.clickup.com/api/v2'
+const BASE_URL_V3 = 'https://api.clickup.com/api/v3'
 const MAX_PAGES = 100
 
 export interface CustomField {
@@ -188,6 +189,29 @@ export interface Attachment {
   url: string
 }
 
+export interface Doc {
+  id: string
+  name: string
+  workspace_id: number
+  date_created?: string
+  date_updated?: string
+  pages?: DocPage[]
+}
+
+export interface DocPage {
+  id: string
+  doc_id: string
+  name: string
+  content?: string
+  parent_page_id?: string
+  date_created?: number
+  date_updated?: number
+  creator_id?: number
+  archived?: boolean
+  deleted?: boolean
+  pages?: DocPage[]
+}
+
 interface ClientConfig {
   apiToken: string
   teamId?: string
@@ -245,6 +269,30 @@ export class ClickUpClient {
       const raw = data.err ?? data.error ?? data.ECODE ?? res.statusText
       const errMsg = typeof raw === 'string' ? raw : JSON.stringify(raw)
       throw new Error(`ClickUp API error ${res.status}: ${errMsg}`)
+    }
+    return data as T
+  }
+
+  private async requestV3<T>(path: string, options: RequestInit = {}): Promise<T> {
+    const res = await fetch(`${BASE_URL_V3}${path}`, {
+      ...options,
+      signal: AbortSignal.timeout(30_000),
+      headers: {
+        Authorization: this.apiToken,
+        ...(options.body ? { 'Content-Type': 'application/json' } : {}),
+        ...options.headers,
+      },
+    })
+    let data: Record<string, unknown>
+    try {
+      data = (await res.json()) as Record<string, unknown>
+    } catch {
+      throw new Error(`ClickUp API error ${res.status}: response was not valid JSON`)
+    }
+    if (!res.ok) {
+      const raw = data.err ?? data.error ?? data.ECODE ?? res.statusText
+      const msg = typeof raw === 'string' ? raw : JSON.stringify(raw)
+      throw new Error(`ClickUp API error ${res.status}: ${msg}`)
     }
     return data as T
   }
@@ -652,5 +700,62 @@ export class ClickUpClient {
       throw new Error(`ClickUp API error ${res.status}: response was not valid JSON`)
     }
     return data
+  }
+
+  async getDocs(workspaceId: string): Promise<Doc[]> {
+    const data = await this.requestV3<{ docs: Doc[] }>(`/workspaces/${workspaceId}/docs`)
+    return data.docs ?? []
+  }
+
+  async getDocPage(workspaceId: string, docId: string, pageId: string): Promise<DocPage> {
+    return this.requestV3<DocPage>(
+      `/workspaces/${workspaceId}/docs/${docId}/pages/${pageId}?content_format=text/md`,
+    )
+  }
+
+  async createDoc(
+    workspaceId: string,
+    title: string,
+    content?: string,
+    parentId?: string,
+  ): Promise<Doc> {
+    const body: Record<string, unknown> = { title }
+    if (content) body.content = content
+    if (parentId) {
+      body.parent_id = parentId
+      body.parent_type = 'doc'
+    }
+    return this.requestV3<Doc>(`/workspaces/${workspaceId}/docs`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    })
+  }
+
+  async createDocPage(
+    workspaceId: string,
+    docId: string,
+    name: string,
+    content?: string,
+    parentPageId?: string,
+  ): Promise<DocPage> {
+    const body: Record<string, unknown> = { name, content_format: 'text/md' }
+    if (content) body.content = content
+    if (parentPageId) body.parent_page_id = parentPageId
+    return this.requestV3<DocPage>(`/workspaces/${workspaceId}/docs/${docId}/pages`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    })
+  }
+
+  async editDocPage(
+    workspaceId: string,
+    docId: string,
+    pageId: string,
+    updates: { name?: string; content?: string },
+  ): Promise<DocPage> {
+    return this.requestV3<DocPage>(`/workspaces/${workspaceId}/docs/${docId}/pages/${pageId}`, {
+      method: 'PUT',
+      body: JSON.stringify(updates),
+    })
   }
 }

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -11,7 +11,7 @@ function bashCompletion(name: string): string {
     cword=$COMP_CWORD
   fi
 
-  local commands="init auth tasks task update create sprint sprints subtasks comment comment-edit comment-delete comments replies reply activity lists spaces inbox assigned open search summary overdue assign depend link attach move field delete tag checklist time config completion"
+  local commands="init auth tasks task update create sprint sprints subtasks comment comment-edit comment-delete comments replies reply activity lists spaces inbox assigned open search summary overdue assign depend link attach move field delete tag checklist time docs doc doc-create doc-page-create doc-page-edit config completion"
 
   if [[ $cword -eq 1 ]]; then
     COMPREPLY=($(compgen -W "$commands --help --version" -- "$cur"))
@@ -135,6 +135,21 @@ function bashCompletion(name: string): string {
     attach)
       COMPREPLY=($(compgen -f -- "$cur"))
       ;;
+    docs)
+      COMPREPLY=($(compgen -W "--json" -- "$cur"))
+      ;;
+    doc)
+      COMPREPLY=($(compgen -W "--json" -- "$cur"))
+      ;;
+    doc-create)
+      COMPREPLY=($(compgen -W "-c --content --json" -- "$cur"))
+      ;;
+    doc-page-create)
+      COMPREPLY=($(compgen -W "-c --content --parent-page --json" -- "$cur"))
+      ;;
+    doc-page-edit)
+      COMPREPLY=($(compgen -W "--name -c --content --json" -- "$cur"))
+      ;;
     config)
       if [[ $cword -eq 2 ]]; then
         COMPREPLY=($(compgen -W "get set path" -- "$cur"))
@@ -196,6 +211,11 @@ _${name}() {
     'reply:Reply to a comment'
     'link:Add or remove a link between two tasks'
     'attach:Upload a file attachment to a task'
+    'docs:List workspace docs'
+    'doc:View a doc page'
+    'doc-create:Create a new doc'
+    'doc-page-create:Create a page in a doc'
+    'doc-page-edit:Edit a doc page'
     'config:Manage CLI configuration'
     'completion:Output shell completion script'
   )
@@ -518,6 +538,39 @@ _${name}() {
             '2:file_path:_files' \\
             '--json[Force JSON output]'
           ;;
+        docs)
+          _arguments \\
+            '1:query:' \\
+            '--json[Force JSON output]'
+          ;;
+        doc)
+          _arguments \\
+            '1:doc_id:' \\
+            '2:page_id:' \\
+            '--json[Force JSON output]'
+          ;;
+        doc-create)
+          _arguments \\
+            '1:title:' \\
+            '(-c --content)'{-c,--content}'[Initial content]:text:' \\
+            '--json[Force JSON output]'
+          ;;
+        doc-page-create)
+          _arguments \\
+            '1:doc_id:' \\
+            '2:name:' \\
+            '(-c --content)'{-c,--content}'[Page content]:text:' \\
+            '--parent-page[Parent page ID]:page_id:' \\
+            '--json[Force JSON output]'
+          ;;
+        doc-page-edit)
+          _arguments \\
+            '1:doc_id:' \\
+            '2:page_id:' \\
+            '--name[New page name]:text:' \\
+            '(-c --content)'{-c,--content}'[New page content]:text:' \\
+            '--json[Force JSON output]'
+          ;;
         config)
           local -a config_cmds
           config_cmds=(
@@ -593,6 +646,11 @@ complete -c ${name} -n __fish_use_subcommand -a replies -d 'List threaded replie
 complete -c ${name} -n __fish_use_subcommand -a reply -d 'Reply to a comment'
 complete -c ${name} -n __fish_use_subcommand -a link -d 'Add or remove a link between two tasks'
 complete -c ${name} -n __fish_use_subcommand -a attach -d 'Upload a file attachment to a task'
+complete -c ${name} -n __fish_use_subcommand -a docs -d 'List workspace docs'
+complete -c ${name} -n __fish_use_subcommand -a doc -d 'View a doc page'
+complete -c ${name} -n __fish_use_subcommand -a doc-create -d 'Create a new doc'
+complete -c ${name} -n __fish_use_subcommand -a doc-page-create -d 'Create a page in a doc'
+complete -c ${name} -n __fish_use_subcommand -a doc-page-edit -d 'Edit a doc page'
 complete -c ${name} -n __fish_use_subcommand -a config -d 'Manage CLI configuration'
 complete -c ${name} -n __fish_use_subcommand -a completion -d 'Output shell completion script'
 
@@ -745,6 +803,21 @@ complete -c ${name} -n '__fish_seen_subcommand_from comment-edit' -s m -l messag
 complete -c ${name} -n '__fish_seen_subcommand_from comment-edit' -l resolved -d 'Mark comment as resolved'
 complete -c ${name} -n '__fish_seen_subcommand_from comment-edit' -l unresolved -d 'Mark comment as unresolved'
 complete -c ${name} -n '__fish_seen_subcommand_from comment-edit' -l json -d 'Force JSON output'
+
+complete -c ${name} -n '__fish_seen_subcommand_from docs' -l json -d 'Force JSON output'
+
+complete -c ${name} -n '__fish_seen_subcommand_from doc' -l json -d 'Force JSON output'
+
+complete -c ${name} -n '__fish_seen_subcommand_from doc-create' -s c -l content -d 'Initial content'
+complete -c ${name} -n '__fish_seen_subcommand_from doc-create' -l json -d 'Force JSON output'
+
+complete -c ${name} -n '__fish_seen_subcommand_from doc-page-create' -s c -l content -d 'Page content'
+complete -c ${name} -n '__fish_seen_subcommand_from doc-page-create' -l parent-page -d 'Parent page ID'
+complete -c ${name} -n '__fish_seen_subcommand_from doc-page-create' -l json -d 'Force JSON output'
+
+complete -c ${name} -n '__fish_seen_subcommand_from doc-page-edit' -l name -d 'New page name'
+complete -c ${name} -n '__fish_seen_subcommand_from doc-page-edit' -s c -l content -d 'New page content'
+complete -c ${name} -n '__fish_seen_subcommand_from doc-page-edit' -l json -d 'Force JSON output'
 
 complete -c ${name} -n '__fish_seen_subcommand_from config; and not __fish_seen_subcommand_from get set path' -a get -d 'Print a config value'
 complete -c ${name} -n '__fish_seen_subcommand_from config; and not __fish_seen_subcommand_from get set path' -a set -d 'Set a config value'

--- a/src/commands/doc.ts
+++ b/src/commands/doc.ts
@@ -1,0 +1,44 @@
+import { ClickUpClient } from '../api.js'
+import type { Config } from '../config.js'
+import type { DocPage } from '../api.js'
+
+export async function getDocPage(config: Config, docId: string, pageId: string): Promise<DocPage> {
+  const client = new ClickUpClient(config)
+  return client.getDocPage(config.teamId, docId, pageId)
+}
+
+export async function createDoc(
+  config: Config,
+  title: string,
+  content?: string,
+): Promise<{ id: string; title: string }> {
+  if (!title.trim()) throw new Error('Doc title cannot be empty')
+  const client = new ClickUpClient(config)
+  const doc = await client.createDoc(config.teamId, title, content)
+  return { id: doc.id, title: doc.name ?? title }
+}
+
+export async function createDocPage(
+  config: Config,
+  docId: string,
+  name: string,
+  content?: string,
+  parentPageId?: string,
+): Promise<DocPage> {
+  if (!name.trim()) throw new Error('Page name cannot be empty')
+  const client = new ClickUpClient(config)
+  return client.createDocPage(config.teamId, docId, name, content, parentPageId)
+}
+
+export async function editDocPage(
+  config: Config,
+  docId: string,
+  pageId: string,
+  updates: { name?: string; content?: string },
+): Promise<DocPage> {
+  if (!updates.name && !updates.content) {
+    throw new Error('Provide --name or --content to update')
+  }
+  const client = new ClickUpClient(config)
+  return client.editDocPage(config.teamId, docId, pageId, updates)
+}

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -1,0 +1,24 @@
+import chalk from 'chalk'
+import { ClickUpClient } from '../api.js'
+import type { Config } from '../config.js'
+import type { Doc } from '../api.js'
+
+export async function listDocs(config: Config, query?: string): Promise<Doc[]> {
+  const client = new ClickUpClient(config)
+  const docs = await client.getDocs(config.teamId)
+  if (query) {
+    const lower = query.toLowerCase()
+    return docs.filter(d => d.name.toLowerCase().includes(lower))
+  }
+  return docs
+}
+
+export function formatDocs(docs: Doc[]): string {
+  if (docs.length === 0) return 'No docs found'
+  return docs.map(d => `${chalk.bold(d.name)} ${chalk.dim(d.id)}`).join('\n')
+}
+
+export function formatDocsMarkdown(docs: Doc[]): string {
+  if (docs.length === 0) return 'No docs found'
+  return docs.map(d => `- **${d.name}** (${d.id})`).join('\n')
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,8 @@ import {
 } from './commands/replies.js'
 import { manageTaskLink } from './commands/link.js'
 import { attachFile } from './commands/attach.js'
+import { listDocs, formatDocs, formatDocsMarkdown } from './commands/docs.js'
+import { getDocPage, createDoc, createDocPage, editDocPage } from './commands/doc.js'
 import {
   startTimer,
   stopTimer,
@@ -948,6 +950,109 @@ timeCmd
         console.log(formatTimeEntriesMarkdown(entries))
       }
     }),
+  )
+
+program
+  .command('docs [query]')
+  .description('List workspace docs (optionally filter by name)')
+  .option('--json', 'Force JSON output even in terminal')
+  .action(
+    wrapAction(async (query: string | undefined, opts: { json?: boolean }) => {
+      const config = loadConfig()
+      const docs = await listDocs(config, query)
+      if (shouldOutputJson(opts.json ?? false)) {
+        console.log(JSON.stringify(docs, null, 2))
+      } else if (isTTY()) {
+        console.log(formatDocs(docs))
+      } else {
+        console.log(formatDocsMarkdown(docs))
+      }
+    }),
+  )
+
+program
+  .command('doc <docId> <pageId>')
+  .description('View a doc page')
+  .option('--json', 'Force JSON output even in terminal')
+  .action(
+    wrapAction(async (docId: string, pageId: string, opts: { json?: boolean }) => {
+      const config = loadConfig()
+      const page = await getDocPage(config, docId, pageId)
+      if (shouldOutputJson(opts.json ?? false)) {
+        console.log(JSON.stringify(page, null, 2))
+      } else {
+        if (page.name) console.log(`# ${page.name}\n`)
+        console.log(page.content ?? '')
+      }
+    }),
+  )
+
+program
+  .command('doc-create <title>')
+  .description('Create a new doc')
+  .option('-c, --content <text>', 'Initial content (markdown)')
+  .option('--json', 'Force JSON output even in terminal')
+  .action(
+    wrapAction(async (title: string, opts: { content?: string; json?: boolean }) => {
+      const config = loadConfig()
+      const result = await createDoc(config, title, opts.content)
+      if (shouldOutputJson(opts.json ?? false)) {
+        console.log(JSON.stringify(result, null, 2))
+      } else {
+        console.log(`Created doc "${result.title}" (${result.id})`)
+      }
+    }),
+  )
+
+program
+  .command('doc-page-create <docId> <name>')
+  .description('Create a page in a doc')
+  .option('-c, --content <text>', 'Page content (markdown)')
+  .option('--parent-page <pageId>', 'Parent page ID for nesting')
+  .option('--json', 'Force JSON output even in terminal')
+  .action(
+    wrapAction(
+      async (
+        docId: string,
+        name: string,
+        opts: { content?: string; parentPage?: string; json?: boolean },
+      ) => {
+        const config = loadConfig()
+        const page = await createDocPage(config, docId, name, opts.content, opts.parentPage)
+        if (shouldOutputJson(opts.json ?? false)) {
+          console.log(JSON.stringify(page, null, 2))
+        } else {
+          console.log(`Created page "${page.name}" (${page.id}) in doc ${docId}`)
+        }
+      },
+    ),
+  )
+
+program
+  .command('doc-page-edit <docId> <pageId>')
+  .description('Edit a doc page')
+  .option('--name <text>', 'New page name')
+  .option('-c, --content <text>', 'New page content (markdown)')
+  .option('--json', 'Force JSON output even in terminal')
+  .action(
+    wrapAction(
+      async (
+        docId: string,
+        pageId: string,
+        opts: { name?: string; content?: string; json?: boolean },
+      ) => {
+        const config = loadConfig()
+        const page = await editDocPage(config, docId, pageId, {
+          name: opts.name,
+          content: opts.content,
+        })
+        if (shouldOutputJson(opts.json ?? false)) {
+          console.log(JSON.stringify(page, null, 2))
+        } else {
+          console.log(`Updated page "${page.name}" (${page.id})`)
+        }
+      },
+    ),
   )
 
 const configCmd = program.command('config').description('Manage CLI configuration')

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -835,6 +835,90 @@ describe('task links', () => {
   })
 })
 
+describe('Docs API v3 methods', () => {
+  let client: import('../../src/api.js').ClickUpClient
+
+  beforeEach(async () => {
+    vi.stubGlobal('fetch', mockFetch)
+    vi.clearAllMocks()
+    const { ClickUpClient } = await import('../../src/api.js')
+    client = new ClickUpClient({ apiToken: 'pk_test' })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('getDocs sends GET to v3 /workspaces/{id}/docs', async () => {
+    const docs = [{ id: 'd1', name: 'My Doc', workspace_id: 1 }]
+    mockFetch.mockReturnValue(mockResponse({ docs }))
+    const result = await client.getDocs('w1')
+    expect(result).toEqual(docs)
+    const url = String(mockFetch.mock.calls[0]![0])
+    expect(url).toContain('https://api.clickup.com/api/v3/workspaces/w1/docs')
+  })
+
+  it('getDocs returns empty array when docs is missing', async () => {
+    mockFetch.mockReturnValue(mockResponse({}))
+    const result = await client.getDocs('w1')
+    expect(result).toEqual([])
+  })
+
+  it('getDocPage sends GET to v3 /workspaces/{id}/docs/{docId}/pages/{pageId}', async () => {
+    const page = { id: 'p1', doc_id: 'd1', name: 'Page 1', content: '# Hello' }
+    mockFetch.mockReturnValue(mockResponse(page))
+    const result = await client.getDocPage('w1', 'd1', 'p1')
+    expect(result).toEqual(page)
+    const url = String(mockFetch.mock.calls[0]![0])
+    expect(url).toContain('https://api.clickup.com/api/v3/workspaces/w1/docs/d1/pages/p1')
+    expect(url).toContain('content_format=text/md')
+  })
+
+  it('createDoc sends POST to v3 /workspaces/{id}/docs', async () => {
+    const doc = { id: 'd1', name: 'New Doc', workspace_id: 1 }
+    mockFetch.mockReturnValue(mockResponse(doc))
+    const result = await client.createDoc('w1', 'New Doc', '# Content')
+    expect(result).toEqual(doc)
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('https://api.clickup.com/api/v3/workspaces/w1/docs'),
+      expect.objectContaining({ method: 'POST' }),
+    )
+    const callArgs = mockFetch.mock.calls[0]![1] as RequestInit
+    const body = JSON.parse(callArgs.body as string) as Record<string, unknown>
+    expect(body.title).toBe('New Doc')
+    expect(body.content).toBe('# Content')
+  })
+
+  it('createDocPage sends POST to v3 /workspaces/{id}/docs/{docId}/pages', async () => {
+    const page = { id: 'p1', doc_id: 'd1', name: 'Page 1' }
+    mockFetch.mockReturnValue(mockResponse(page))
+    const result = await client.createDocPage('w1', 'd1', 'Page 1', '# Content', 'p0')
+    expect(result).toEqual(page)
+    const url = String(mockFetch.mock.calls[0]![0])
+    expect(url).toContain('https://api.clickup.com/api/v3/workspaces/w1/docs/d1/pages')
+    const callArgs = mockFetch.mock.calls[0]![1] as RequestInit
+    const body = JSON.parse(callArgs.body as string) as Record<string, unknown>
+    expect(body.name).toBe('Page 1')
+    expect(body.content).toBe('# Content')
+    expect(body.parent_page_id).toBe('p0')
+    expect(body.content_format).toBe('text/md')
+  })
+
+  it('editDocPage sends PUT to v3 /workspaces/{id}/docs/{docId}/pages/{pageId}', async () => {
+    const page = { id: 'p1', doc_id: 'd1', name: 'Updated' }
+    mockFetch.mockReturnValue(mockResponse(page))
+    const result = await client.editDocPage('w1', 'd1', 'p1', { name: 'Updated', content: '# New' })
+    expect(result).toEqual(page)
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('https://api.clickup.com/api/v3/workspaces/w1/docs/d1/pages/p1'),
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ name: 'Updated', content: '# New' }),
+      }),
+    )
+  })
+})
+
 describe('postComment', () => {
   let client: import('../../src/api.js').ClickUpClient
 

--- a/tests/unit/commands/doc.test.ts
+++ b/tests/unit/commands/doc.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockGetDocPage = vi.fn()
+const mockCreateDoc = vi.fn()
+const mockCreateDocPage = vi.fn()
+const mockEditDocPage = vi.fn()
+
+vi.mock('../../../src/api.js', () => ({
+  ClickUpClient: vi.fn().mockImplementation(() => ({
+    getDocPage: mockGetDocPage,
+    createDoc: mockCreateDoc,
+    createDocPage: mockCreateDocPage,
+    editDocPage: mockEditDocPage,
+  })),
+}))
+
+const mockConfig = { apiToken: 'pk_test', teamId: 'team1' }
+
+describe('getDocPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns doc page from API', async () => {
+    const page = { id: 'p1', doc_id: 'd1', name: 'Intro', content: '# Hello' }
+    mockGetDocPage.mockResolvedValue(page)
+    const { getDocPage } = await import('../../../src/commands/doc.js')
+    const result = await getDocPage(mockConfig, 'd1', 'p1')
+    expect(result).toEqual(page)
+    expect(mockGetDocPage).toHaveBeenCalledWith('team1', 'd1', 'p1')
+  })
+})
+
+describe('createDoc', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('creates a doc and returns id and title', async () => {
+    mockCreateDoc.mockResolvedValue({ id: 'd1', name: 'New Doc', workspace_id: 1 })
+    const { createDoc } = await import('../../../src/commands/doc.js')
+    const result = await createDoc(mockConfig, 'New Doc')
+    expect(result).toEqual({ id: 'd1', title: 'New Doc' })
+    expect(mockCreateDoc).toHaveBeenCalledWith('team1', 'New Doc', undefined)
+  })
+
+  it('passes content when provided', async () => {
+    mockCreateDoc.mockResolvedValue({ id: 'd1', name: 'Doc', workspace_id: 1 })
+    const { createDoc } = await import('../../../src/commands/doc.js')
+    await createDoc(mockConfig, 'Doc', '# Content')
+    expect(mockCreateDoc).toHaveBeenCalledWith('team1', 'Doc', '# Content')
+  })
+
+  it('throws on empty title', async () => {
+    const { createDoc } = await import('../../../src/commands/doc.js')
+    await expect(createDoc(mockConfig, '  ')).rejects.toThrow('Doc title cannot be empty')
+  })
+})
+
+describe('createDocPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('creates a page in a doc', async () => {
+    const page = { id: 'p1', doc_id: 'd1', name: 'Page 1' }
+    mockCreateDocPage.mockResolvedValue(page)
+    const { createDocPage } = await import('../../../src/commands/doc.js')
+    const result = await createDocPage(mockConfig, 'd1', 'Page 1')
+    expect(result).toEqual(page)
+    expect(mockCreateDocPage).toHaveBeenCalledWith('team1', 'd1', 'Page 1', undefined, undefined)
+  })
+
+  it('passes content and parentPageId when provided', async () => {
+    const page = { id: 'p2', doc_id: 'd1', name: 'Sub Page' }
+    mockCreateDocPage.mockResolvedValue(page)
+    const { createDocPage } = await import('../../../src/commands/doc.js')
+    await createDocPage(mockConfig, 'd1', 'Sub Page', '# Content', 'p1')
+    expect(mockCreateDocPage).toHaveBeenCalledWith('team1', 'd1', 'Sub Page', '# Content', 'p1')
+  })
+
+  it('throws on empty name', async () => {
+    const { createDocPage } = await import('../../../src/commands/doc.js')
+    await expect(createDocPage(mockConfig, 'd1', '  ')).rejects.toThrow('Page name cannot be empty')
+  })
+})
+
+describe('editDocPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('edits a doc page with name and content', async () => {
+    const page = { id: 'p1', doc_id: 'd1', name: 'Updated' }
+    mockEditDocPage.mockResolvedValue(page)
+    const { editDocPage } = await import('../../../src/commands/doc.js')
+    const result = await editDocPage(mockConfig, 'd1', 'p1', {
+      name: 'Updated',
+      content: '# New',
+    })
+    expect(result).toEqual(page)
+    expect(mockEditDocPage).toHaveBeenCalledWith('team1', 'd1', 'p1', {
+      name: 'Updated',
+      content: '# New',
+    })
+  })
+
+  it('throws when no updates provided', async () => {
+    const { editDocPage } = await import('../../../src/commands/doc.js')
+    await expect(editDocPage(mockConfig, 'd1', 'p1', {})).rejects.toThrow(
+      'Provide --name or --content to update',
+    )
+  })
+})

--- a/tests/unit/commands/docs.test.ts
+++ b/tests/unit/commands/docs.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockGetDocs = vi.fn()
+
+vi.mock('../../../src/api.js', () => ({
+  ClickUpClient: vi.fn().mockImplementation(() => ({
+    getDocs: mockGetDocs,
+  })),
+}))
+
+const mockConfig = { apiToken: 'pk_test', teamId: 'team1' }
+
+describe('listDocs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns all docs when no query', async () => {
+    const docs = [
+      { id: 'd1', name: 'Design Spec', workspace_id: 1 },
+      { id: 'd2', name: 'API Guide', workspace_id: 1 },
+    ]
+    mockGetDocs.mockResolvedValue(docs)
+    const { listDocs } = await import('../../../src/commands/docs.js')
+    const result = await listDocs(mockConfig, undefined)
+    expect(result).toEqual(docs)
+    expect(mockGetDocs).toHaveBeenCalledWith('team1')
+  })
+
+  it('filters docs by query (case-insensitive)', async () => {
+    const docs = [
+      { id: 'd1', name: 'Design Spec', workspace_id: 1 },
+      { id: 'd2', name: 'API Guide', workspace_id: 1 },
+    ]
+    mockGetDocs.mockResolvedValue(docs)
+    const { listDocs } = await import('../../../src/commands/docs.js')
+    const result = await listDocs(mockConfig, 'design')
+    expect(result).toEqual([docs[0]])
+  })
+
+  it('returns empty array when no docs match query', async () => {
+    mockGetDocs.mockResolvedValue([{ id: 'd1', name: 'Design Spec', workspace_id: 1 }])
+    const { listDocs } = await import('../../../src/commands/docs.js')
+    const result = await listDocs(mockConfig, 'nonexistent')
+    expect(result).toEqual([])
+  })
+})
+
+describe('formatDocs', () => {
+  it('returns "No docs found" for empty array', async () => {
+    const { formatDocs } = await import('../../../src/commands/docs.js')
+    expect(formatDocs([])).toBe('No docs found')
+  })
+
+  it('formats docs with names and IDs', async () => {
+    const { formatDocs } = await import('../../../src/commands/docs.js')
+    const result = formatDocs([{ id: 'd1', name: 'My Doc', workspace_id: 1 }])
+    expect(result).toContain('My Doc')
+    expect(result).toContain('d1')
+  })
+})
+
+describe('formatDocsMarkdown', () => {
+  it('returns "No docs found" for empty array', async () => {
+    const { formatDocsMarkdown } = await import('../../../src/commands/docs.js')
+    expect(formatDocsMarkdown([])).toBe('No docs found')
+  })
+
+  it('formats docs as markdown list', async () => {
+    const { formatDocsMarkdown } = await import('../../../src/commands/docs.js')
+    const result = formatDocsMarkdown([
+      { id: 'd1', name: 'My Doc', workspace_id: 1 },
+      { id: 'd2', name: 'Other Doc', workspace_id: 1 },
+    ])
+    expect(result).toBe('- **My Doc** (d1)\n- **Other Doc** (d2)')
+  })
+})


### PR DESCRIPTION
## Summary

Closes #21

Adds 5 new commands for ClickUp Docs using the v3 API:

- `cup docs [query]` - list workspace docs, filter by name
- `cup doc <docId> <pageId>` - view a doc page (returns markdown)
- `cup doc-create <title>` - create a new doc
- `cup doc-page-create <docId> <name>` - create a page in a doc
- `cup doc-page-edit <docId> <pageId>` - edit a doc page

## Implementation

- Added `requestV3` method to `ClickUpClient` for the `/api/v3/` base path
- `Doc` and `DocPage` types
- Content format defaults to markdown (`text/md`)
- All commands follow the standard JSON/markdown/TTY three-mode output pattern
- Shell completions for all 3 shells

## Tests

578 tests across 45 files (+22 new tests)