### PR TITLE
Fix HTTP 204 handling, empty name validation

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -365,6 +365,12 @@ export class ClickUpClient {
         ...options.headers,
       },
     })
+    if (res.status === 204 || res.headers.get('content-length') === '0') {
+      if (!res.ok) {
+        throw new Error(`ClickUp API error ${res.status}: ${res.statusText}`)
+      }
+      return {} as T
+    }
     let parsed: unknown
     try {
       parsed = await res.json()

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -22,6 +22,8 @@ export async function createTask(
   config: Config,
   options: CreateOptions,
 ): Promise<{ id: string; name: string; url: string }> {
+  if (!options.name.trim()) throw new Error('Task name cannot be empty')
+
   const client = new ClickUpClient(config)
 
   let listId = options.list

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -68,7 +68,10 @@ export interface UpdateCommandOptions {
 
 export function buildUpdatePayload(opts: UpdateCommandOptions): UpdateTaskOptions {
   const payload: UpdateTaskOptions = {}
-  if (opts.name !== undefined) payload.name = opts.name
+  if (opts.name !== undefined) {
+    if (!opts.name.trim()) throw new Error('Task name cannot be empty')
+    payload.name = opts.name
+  }
   if (opts.description !== undefined) payload.markdown_content = opts.description
   if (opts.status !== undefined) payload.status = opts.status
   if (opts.priority !== undefined) payload.priority = parsePriority(opts.priority)

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -7,6 +7,7 @@ function mockResponse(data: unknown, ok = true) {
     ok,
     status: ok ? 200 : 400,
     statusText: ok ? 'OK' : 'Bad Request',
+    headers: new Headers({ 'content-length': '1' }),
     json: () => Promise.resolve(data),
   })
 }
@@ -207,6 +208,7 @@ describe('ClickUpClient', () => {
         ok: false,
         status: 502,
         statusText: 'Bad Gateway',
+        headers: new Headers({ 'content-length': '1' }),
         json: () => Promise.reject(new SyntaxError('Unexpected token')),
       }),
     )
@@ -491,6 +493,60 @@ describe('custom fields', () => {
   })
 })
 
+describe('HTTP 204 No Content handling', () => {
+  let client: import('../../src/api.js').ClickUpClient
+
+  beforeEach(async () => {
+    vi.stubGlobal('fetch', mockFetch)
+    vi.clearAllMocks()
+    const { ClickUpClient } = await import('../../src/api.js')
+    client = new ClickUpClient({ apiToken: 'pk_test' })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('handles 204 response without throwing', async () => {
+    mockFetch.mockReturnValue(
+      Promise.resolve({
+        ok: true,
+        status: 204,
+        statusText: 'No Content',
+        headers: new Headers(),
+        json: () => Promise.reject(new SyntaxError('Unexpected end of JSON input')),
+      }),
+    )
+    await expect(client.deleteTask('t1')).resolves.not.toThrow()
+  })
+
+  it('handles response with content-length 0', async () => {
+    mockFetch.mockReturnValue(
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers({ 'content-length': '0' }),
+        json: () => Promise.reject(new SyntaxError('Unexpected end of JSON input')),
+      }),
+    )
+    await expect(client.deleteComment('c1')).resolves.not.toThrow()
+  })
+
+  it('throws on non-ok 204 response', async () => {
+    mockFetch.mockReturnValue(
+      Promise.resolve({
+        ok: false,
+        status: 204,
+        statusText: 'No Content',
+        headers: new Headers(),
+        json: () => Promise.reject(new SyntaxError('Unexpected end of JSON input')),
+      }),
+    )
+    await expect(client.deleteTask('t1')).rejects.toThrow('ClickUp API error 204: No Content')
+  })
+})
+
 describe('deleteTask', () => {
   let client: import('../../src/api.js').ClickUpClient
 
@@ -512,6 +568,19 @@ describe('deleteTask', () => {
       'https://api.clickup.com/api/v2/task/t1',
       expect.objectContaining({ method: 'DELETE' }),
     )
+  })
+
+  it('succeeds with 204 No Content response', async () => {
+    mockFetch.mockReturnValue(
+      Promise.resolve({
+        ok: true,
+        status: 204,
+        statusText: 'No Content',
+        headers: new Headers(),
+        json: () => Promise.reject(new SyntaxError('Unexpected end of JSON input')),
+      }),
+    )
+    await expect(client.deleteTask('t1')).resolves.not.toThrow()
   })
 })
 

--- a/tests/unit/commands/create.test.ts
+++ b/tests/unit/commands/create.test.ts
@@ -83,6 +83,20 @@ describe('createTask', () => {
     ).rejects.toThrow('--list or --parent')
   })
 
+  it('throws on empty name', async () => {
+    const { createTask } = await import('../../../src/commands/create.js')
+    await expect(
+      createTask({ apiToken: 'pk_t', teamId: 'tm_1' }, { list: 'l1', name: '' }),
+    ).rejects.toThrow('Task name cannot be empty')
+  })
+
+  it('throws on whitespace-only name', async () => {
+    const { createTask } = await import('../../../src/commands/create.js')
+    await expect(
+      createTask({ apiToken: 'pk_t', teamId: 'tm_1' }, { list: 'l1', name: '   ' }),
+    ).rejects.toThrow('Task name cannot be empty')
+  })
+
   it('passes priority to API as numeric value', async () => {
     const { createTask } = await import('../../../src/commands/create.js')
     await createTask(

--- a/tests/unit/commands/update.test.ts
+++ b/tests/unit/commands/update.test.ts
@@ -252,6 +252,16 @@ describe('buildUpdatePayload', () => {
     const { buildUpdatePayload } = await import('../../../src/commands/update.js')
     expect(() => buildUpdatePayload({ assignee: 'abc' })).toThrow('numeric user ID')
   })
+
+  it('throws on empty name', async () => {
+    const { buildUpdatePayload } = await import('../../../src/commands/update.js')
+    expect(() => buildUpdatePayload({ name: '' })).toThrow('Task name cannot be empty')
+  })
+
+  it('throws on whitespace-only name', async () => {
+    const { buildUpdatePayload } = await import('../../../src/commands/update.js')
+    expect(() => buildUpdatePayload({ name: '   ' })).toThrow('Task name cannot be empty')
+  })
 })
 
 describe('fuzzy status matching', () => {


### PR DESCRIPTION
## Summary

Fixes #24

### Bug 1: `_fetch` fails on HTTP 204 No Content (high severity)

The `_fetch` method unconditionally called `res.json()` on every response. HTTP 204 (No Content) has no body, so this threw "response was not valid JSON" on every successful DELETE operation - tasks, comments, checklists, tags, goals, docs, etc.

Fixed by checking for 204/empty-body before parsing. Returns `{} as T` for void-returning methods.

### Bug 2: `cup update -n ""` accepts empty name

`buildUpdatePayload` passed empty strings through without validation. Now throws "Task name cannot be empty" for empty or whitespace-only names.

### Bug 3: `cup create -n ""` misleading error

Empty name wasn't validated before the list/parent check, producing a confusing error. Now validates name first.

### Not a bug: Windows UV assertion noise

The `Assertion failed: !(handle->flags & UV_HANDLE_CLOSING)` messages are a known Node.js/libuv issue on Windows during process exit with pending timers. Not actionable from our side.

## Tests

+8 new tests (746 total): 204 handling, deleteTask with 204, empty/whitespace name in update and create.