### PR TITLE
feat: accept --list-id as an alias for --list

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3756,10 +3756,27 @@ export function buildProgram(programName = basename(process.argv[1] ?? 'cup')): 
   return program
 }
 
+/**
+ * Rewrites the `--list-id` alias to the canonical `--list` flag.
+ *
+ * ClickUp's API names the list identifier `list_id` (GET /api/v2/list/{list_id}/task),
+ * so `--list-id` is the flag many humans and AI agents intuitively reach for. Commander
+ * only defines `--list`, so we normalize the alias once at the single parse gate — covering
+ * every command that accepts `--list` (tasks, create, time list, …) without duplicating the
+ * option declaration. The canonical `--list` and unrelated arguments are left untouched.
+ */
+export function normalizeListIdAlias(argv: string[]): string[] {
+  return argv.map(arg => {
+    if (arg === '--list-id') return '--list'
+    if (arg.startsWith('--list-id=')) return `--list=${arg.slice('--list-id='.length)}`
+    return arg
+  })
+}
+
 export async function run(argv = process.argv): Promise<void> {
   const programName = basename(argv[1] ?? 'cup')
   const program = buildProgram(programName)
-  await program.parseAsync(argv)
+  await program.parseAsync(normalizeListIdAlias(argv))
 }
 
 process.on('SIGINT', () => {

--- a/tests/unit/list-id-alias.test.ts
+++ b/tests/unit/list-id-alias.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeListIdAlias } from '../../src/index.js'
+
+describe('normalizeListIdAlias', () => {
+  it('rewrites a standalone --list-id to --list', () => {
+    expect(normalizeListIdAlias(['node', 'cup', 'tasks', '--list-id', '901327405763'])).toEqual([
+      'node',
+      'cup',
+      'tasks',
+      '--list',
+      '901327405763',
+    ])
+  })
+
+  it('rewrites --list-id=VALUE to --list=VALUE', () => {
+    expect(normalizeListIdAlias(['node', 'cup', 'tasks', '--list-id=901327405763'])).toEqual([
+      'node',
+      'cup',
+      'tasks',
+      '--list=901327405763',
+    ])
+  })
+
+  it('leaves the canonical --list untouched', () => {
+    expect(normalizeListIdAlias(['node', 'cup', 'tasks', '--list', '901327405763'])).toEqual([
+      'node',
+      'cup',
+      'tasks',
+      '--list',
+      '901327405763',
+    ])
+  })
+
+  it('does not touch unrelated arguments', () => {
+    expect(
+      normalizeListIdAlias(['node', 'cup', 'create', '--name', 'x', '--parent', 'abc']),
+    ).toEqual(['node', 'cup', 'create', '--name', 'x', '--parent', 'abc'])
+  })
+
+  it('rewrites every occurrence in the same argv', () => {
+    expect(normalizeListIdAlias(['--list-id', 'a', '--list-id=b'])).toEqual([
+      '--list',
+      'a',
+      '--list=b',
+    ])
+  })
+
+  it('does not rewrite flags that merely start with --list', () => {
+    expect(normalizeListIdAlias(['cup', 'tasks', '--list-ids', 'x'])).toEqual([
+      'cup',
+      'tasks',
+      '--list-ids',
+      'x',
+    ])
+  })
+})


### PR DESCRIPTION
## What

Adds `--list-id` as an alias for the existing `--list` flag, across every command that accepts it.

## Why

ClickUp's own API names the list identifier `list_id` (`GET /api/v2/list/{list_id}/task`), so `--list-id` is the flag many humans — and AI agents especially — intuitively reach for. Today commander rejects it:

```
error: unknown option '--list-id'
```

## How

A single argv normalization at the one parse gate (`run()` → `parseAsync`) rewrites `--list-id` and `--list-id=<value>` to `--list` / `--list=<value>` before parsing. One point covers **every** command that uses `--list` (`tasks`, `create`, `time list`, …) without duplicating the option across its ~6 declaration sites. The canonical `--list` and unrelated args (e.g. a hypothetical `--list-ids`) are left untouched.

## Tests

`normalizeListIdAlias()` is a pure, exported function with 6 unit tests in `tests/unit/list-id-alias.test.ts`. Full local gate is green: `typecheck` + `lint` (no issues) + **1234 tests** + `build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)