### PR TITLE
fix: resolve custom task IDs in task-reference custom fields

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -103,6 +103,8 @@ cup task PROJ-123
 cup update DEV-42 --status done
 cup comment PROJ-456 -m "Fixed in latest commit"
 cup subtasks DEV-100
+cup field abc123 --set "Epic" PROJ-123          # task-relationship field values too
+cup create -n "Task" -l <listId> --field "Epic" PROJ-123
 ```
 
 Custom ID resolution uses the `teamId` from your config, which is required (`cup init` sets it up).

--- a/src/commands/bulk.ts
+++ b/src/commands/bulk.ts
@@ -2,7 +2,7 @@ import { ClickUpClient } from '../api.js'
 import type { Config } from '../config.js'
 import { runInBatches, type BatchOutcome } from '../util/batch.js'
 import { resolveAssigneeId, parseDueDate, parsePriority } from './update.js'
-import { findFieldByName, parseFieldValue } from './field.js'
+import { findFieldByName, parseFieldValue, resolveTaskFieldValue } from './field.js'
 
 export type BulkResult = { updated: number; failed: Array<{ id: string; reason: string }> }
 
@@ -103,7 +103,7 @@ export async function bulkField(
   const firstTask = await client.getTask(taskIds[0]!)
   const fields = firstTask.custom_fields ?? []
   const field = findFieldByName(fields, fieldName)
-  const parsed = parseFieldValue(field, rawValue)
+  const parsed = await resolveTaskFieldValue(client, field, parseFieldValue(field, rawValue))
   const outcomes = await runInBatches(taskIds, BULK_CONCURRENCY, id =>
     client.setCustomFieldValue(id, field.id, parsed),
   )

--- a/src/commands/field.ts
+++ b/src/commands/field.ts
@@ -171,6 +171,23 @@ export function parseFieldValue(field: FieldDescriptor, rawValue: string): unkno
   }
 }
 
+/**
+ * Resolve task references inside a parsed `tasks`-relationship value to native
+ * task IDs. Users pass custom IDs (PROD-123) and task URLs anywhere a task is
+ * referenced; ClickUp's custom-field endpoints accept only native IDs, and
+ * reject anything else with a misleading "not authorized" error.
+ * Non-relationship values pass through untouched.
+ */
+export async function resolveTaskFieldValue(
+  client: Pick<ClickUpClient, 'resolveTaskId'>,
+  field: FieldDescriptor,
+  parsed: unknown,
+): Promise<unknown> {
+  if (field.type !== 'tasks') return parsed
+  const { add } = parsed as { add: string[] }
+  return { add: await Promise.all(add.map(id => client.resolveTaskId(id))) }
+}
+
 export async function setCustomField(
   config: Config,
   taskId: string,
@@ -188,7 +205,7 @@ export async function setCustomField(
   if (opts.set) {
     const [fieldName, rawValue] = opts.set
     const field = findFieldByName(fields, fieldName)
-    const parsed = parseFieldValue(field, rawValue)
+    const parsed = await resolveTaskFieldValue(client, field, parseFieldValue(field, rawValue))
     await client.setCustomFieldValue(taskId, field.id, parsed)
     results.push({ taskId, field: field.name, action: 'set', value: parsed })
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,12 @@ import { manageDependency } from './commands/depend.js'
 import type { DependOptions } from './commands/depend.js'
 import { moveTask } from './commands/move.js'
 import type { MoveOptions } from './commands/move.js'
-import { setCustomField, findFieldByName, parseFieldValue } from './commands/field.js'
+import {
+  setCustomField,
+  findFieldByName,
+  parseFieldValue,
+  resolveTaskFieldValue,
+} from './commands/field.js'
 import { deleteTaskCommand } from './commands/delete.js'
 import { deleteListCommand } from './commands/list-delete.js'
 import { deleteFolderCommand } from './commands/folder-delete.js'
@@ -735,7 +740,11 @@ export function buildProgram(programName = basename(process.argv[1] ?? 'cup')): 
               const fieldName = opts.field[i]!
               const rawValue = opts.field[i + 1]!
               const field = findFieldByName(fields, fieldName)
-              const value = parseFieldValue(field, rawValue)
+              const value = await resolveTaskFieldValue(
+                client,
+                field,
+                parseFieldValue(field, rawValue),
+              )
               customFields.push({ id: field.id, value })
             }
             opts.customFields = customFields

--- a/tests/unit/commands/bulk.test.ts
+++ b/tests/unit/commands/bulk.test.ts
@@ -7,6 +7,7 @@ const mockRemoveTagFromTask = vi.fn().mockResolvedValue(undefined)
 const mockGetTask = vi.fn()
 const mockSetCustomFieldValue = vi.fn().mockResolvedValue(undefined)
 const mockMoveTaskToList = vi.fn().mockResolvedValue(undefined)
+const mockResolveTaskId = vi.fn()
 
 vi.mock('../../../src/api.js', () => ({
   ClickUpClient: vi.fn().mockImplementation(function () {
@@ -18,6 +19,7 @@ vi.mock('../../../src/api.js', () => ({
       getTask: mockGetTask,
       setCustomFieldValue: mockSetCustomFieldValue,
       moveTaskToList: mockMoveTaskToList,
+      resolveTaskId: mockResolveTaskId,
       getUserTimezone: vi.fn().mockResolvedValue(undefined),
     }
   }),
@@ -285,6 +287,7 @@ describe('bulkField', () => {
     custom_fields: [
       { id: 'f-notes', name: 'Notes', type: 'text', value: null, type_config: {} },
       { id: 'f-score', name: 'Score', type: 'number', value: null, type_config: {} },
+      { id: 'f-epic', name: 'Epic', type: 'tasks', value: null, type_config: {} },
       {
         id: 'f-stage',
         name: 'Stage',
@@ -304,6 +307,19 @@ describe('bulkField', () => {
     vi.clearAllMocks()
     mockGetTask.mockResolvedValue(taskWithFields)
     mockSetCustomFieldValue.mockResolvedValue(undefined)
+    mockResolveTaskId.mockImplementation(async (id: string) => id)
+  })
+
+  it('resolves custom task IDs in a tasks relationship field once for the whole batch', async () => {
+    mockResolveTaskId.mockImplementation(async (id: string) => (id === 'PROD-123' ? 'native1' : id))
+    const { bulkField } = await import('../../../src/commands/bulk.js')
+    const result = await bulkField(mockConfig, 'Epic', 'PROD-123', ['t1', 't2', 't3'])
+
+    expect(mockResolveTaskId).toHaveBeenCalledTimes(1)
+    expect(mockSetCustomFieldValue).toHaveBeenCalledWith('t1', 'f-epic', { add: ['native1'] })
+    expect(mockSetCustomFieldValue).toHaveBeenCalledWith('t2', 'f-epic', { add: ['native1'] })
+    expect(mockSetCustomFieldValue).toHaveBeenCalledWith('t3', 'f-epic', { add: ['native1'] })
+    expect(result).toEqual({ updated: 3, failed: [] })
   })
 
   it('fetches the first task to resolve the field ID', async () => {

--- a/tests/unit/commands/field.test.ts
+++ b/tests/unit/commands/field.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 const mockGetTask = vi.fn()
 const mockSetCustomFieldValue = vi.fn().mockResolvedValue(undefined)
 const mockRemoveCustomFieldValue = vi.fn().mockResolvedValue(undefined)
+const mockResolveTaskId = vi.fn()
 
 vi.mock('../../../src/api.js', () => ({
   ClickUpClient: vi.fn().mockImplementation(function () {
@@ -10,6 +11,7 @@ vi.mock('../../../src/api.js', () => ({
       getTask: mockGetTask,
       setCustomFieldValue: mockSetCustomFieldValue,
       removeCustomFieldValue: mockRemoveCustomFieldValue,
+      resolveTaskId: mockResolveTaskId,
     }
   }),
 }))
@@ -67,6 +69,7 @@ describe('setCustomField', () => {
     mockGetTask.mockReset().mockResolvedValue(taskWithFields)
     mockSetCustomFieldValue.mockReset().mockResolvedValue(undefined)
     mockRemoveCustomFieldValue.mockReset().mockResolvedValue(undefined)
+    mockResolveTaskId.mockReset().mockImplementation(async (id: string) => id)
   })
 
   it('sets a text field by name', async () => {
@@ -242,6 +245,32 @@ describe('setCustomField', () => {
       add: ['task1', 'task2'],
     })
     expect(results[0]!.value).toEqual({ add: ['task1', 'task2'] })
+  })
+
+  it('resolves custom task IDs and URLs in a tasks relationship field', async () => {
+    mockResolveTaskId.mockImplementation(async (id: string) => {
+      if (id === 'PROD-123') return 'native1'
+      if (id === 'https://app.clickup.com/t/abc999') return 'abc999'
+      return id
+    })
+    const { setCustomField } = await import('../../../src/commands/field.js')
+    const { results } = await setCustomField(config, 'task1', {
+      set: ['Related Tasks', 'PROD-123, https://app.clickup.com/t/abc999, plain1'],
+    })
+    expect(mockResolveTaskId).toHaveBeenCalledWith('PROD-123')
+    expect(mockResolveTaskId).toHaveBeenCalledWith('https://app.clickup.com/t/abc999')
+    expect(mockResolveTaskId).toHaveBeenCalledWith('plain1')
+    expect(mockSetCustomFieldValue).toHaveBeenCalledWith('task1', 'cf_tasks', {
+      add: ['native1', 'abc999', 'plain1'],
+    })
+    expect(results[0]!.value).toEqual({ add: ['native1', 'abc999', 'plain1'] })
+  })
+
+  it('does not resolve task IDs for non-relationship fields', async () => {
+    const { setCustomField } = await import('../../../src/commands/field.js')
+    await setCustomField(config, 'task1', { set: ['Notes', 'PROD-123'] })
+    expect(mockResolveTaskId).not.toHaveBeenCalled()
+    expect(mockSetCustomFieldValue).toHaveBeenCalledWith('task1', 'uuid-text', 'PROD-123')
   })
 
   it('sets users (people) field', async () => {

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -360,6 +360,71 @@ describe('cup field --value-file', () => {
   })
 })
 
+describe('cup create --field with task-relationship values', () => {
+  const mockGetListCustomFields = vi.fn()
+  const mockResolveTaskId = vi.fn()
+  const mockCreateTaskApi = vi.fn()
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    mockLoadConfig.mockClear().mockReturnValue(config)
+    mockIsTTY.mockReset().mockReturnValue(false)
+    mockShouldOutputJson.mockReset().mockReturnValue(false)
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    process.exitCode = undefined
+    mockGetListCustomFields
+      .mockReset()
+      .mockResolvedValue([
+        { id: 'f-epic', name: 'Epic', type: 'tasks', value: null, type_config: {} },
+      ])
+    mockResolveTaskId
+      .mockReset()
+      .mockImplementation(async (id: string) => (id === 'PROD-123' ? 'native1' : id))
+    mockCreateTaskApi
+      .mockReset()
+      .mockResolvedValue({ id: 't-new', name: 'Task', url: 'https://app.clickup.com/t/t-new' })
+    vi.doMock('../../src/api.js', async importOriginal => {
+      const actual = await importOriginal<typeof import('../../src/api.js')>()
+      return {
+        ...actual,
+        ClickUpClient: vi.fn().mockImplementation(function () {
+          return {
+            getListCustomFields: mockGetListCustomFields,
+            resolveTaskId: mockResolveTaskId,
+            createTask: mockCreateTaskApi,
+            getUserTimezone: vi.fn().mockResolvedValue(undefined),
+          }
+        }),
+      }
+    })
+  })
+
+  afterEach(() => {
+    vi.doUnmock('../../src/api.js')
+    process.exitCode = undefined
+  })
+
+  it('resolves custom task IDs in --field task-relationship values before creating', async () => {
+    const { buildProgram } = await loadCli()
+    const program = buildProgram('cup')
+
+    await program.parseAsync(
+      ['create', '-n', 'Task', '-l', 'list-1', '--field', 'Epic', 'PROD-123'],
+      { from: 'user' },
+    )
+
+    expect(process.exitCode).toBeUndefined()
+    expect(mockResolveTaskId).toHaveBeenCalledWith('PROD-123')
+    expect(mockCreateTaskApi).toHaveBeenCalledWith(
+      'list-1',
+      expect.objectContaining({
+        custom_fields: [{ id: 'f-epic', value: { add: ['native1'] } }],
+      }),
+    )
+  })
+})
+
 describe('global option collisions', () => {
   it('no subcommand declares a short flag that a global option already uses', async () => {
     // Commander resolves a shared short flag to the global option, so a


### PR DESCRIPTION
Fixes #145.

## Summary

Task-relationship custom-field values (type `tasks`) were passed to ClickUp verbatim, so workspace custom IDs (`PROD-123`) and task URLs failed with a misleading `401 You do not have access to this task`, even though the same forms work everywhere else the CLI accepts a task reference.

## Changes

- New `resolveTaskFieldValue()` in `src/commands/field.ts`: resolves every id in a parsed `{ add: [...] }` relationship value through the existing `ClickUpClient.resolveTaskId()` (custom IDs via lookup, URLs via normalization, native IDs pass through untouched). Non-relationship field types are returned as-is with no extra API calls.
- Wired into all four surfaces from the issue:
  - `cup field --set` and `cup update --field` (both via `setCustomField`)
  - `cup create --field`
  - `cup bulk field --set` (resolution happens once for the batch, not per task)
- Docs: examples of task references in relationship field values under the custom-ID section.

## Tests

Four new unit tests (custom ID + URL + native mix on `field --set`, non-relationship passthrough, batch-level resolution on `bulk field`, end-to-end `create --field` through the CLI action). Written first, watched fail, then implemented.

Full gate: typecheck, lint, format, 1376 tests, build.